### PR TITLE
fix: add /v1 prefix to the all paths and change 200 response of /generate path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ FROM base AS build
 
 WORKDIR /app
 COPY . .
-
 # install dependencies
-# switch to the `npm ci` when https://github.com/asyncapi/.github/issues/123 issue will be resolved
-RUN npm install
+RUN npm ci
 
 # build to a production Javascript
 RUN npm run build:prod
@@ -26,7 +24,8 @@ FROM base AS release
 WORKDIR /app
 COPY --from=build /app/dist ./dist
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
-COPY --from=build /app/package* ./
+# where available (npm@5+)
+COPY package* ./
 # install only production dependencies (defined in "dependencies")
 RUN npm ci --only=production 
 # copy OpenaAPI document

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,8 @@ FROM base AS build
 WORKDIR /app
 COPY . .
 
-# delete package-lock.json - more info https://github.com/asyncapi/.github/issues/123
-# delete that line and install by `npm ci` when mentioned issue will be resolved
-RUN rm -rf package-lock.json
 # install dependencies
+# switch to the `npm ci` when https://github.com/asyncapi/.github/issues/123 issue will be resolved
 RUN npm install
 
 # build to a production Javascript

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ WORKDIR /app
 COPY --from=build /app/dist ./dist
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 COPY --from=build /app/package* ./
-# COPY package* ./
 # install only production dependencies (defined in "dependencies")
 RUN npm ci --only=production 
 # copy OpenaAPI document

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,7 +38,7 @@ paths:
         '200':
           description: Template successfully generated.
           content:
-            application/octet-stream:
+            application/zip:
               schema:
                 type: string
                 format: binary

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,9 +38,10 @@ paths:
         '200':
           description: Template successfully generated.
           content:
-            application/json:
+            application/octet-stream:
               schema:
-                $ref: '#/components/schemas/Template'
+                type: string
+                format: binary
         '400':
           description: Failed to generate the given template due to invalid AsyncAPI document.
           content:

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,7 +60,8 @@ export class App {
 
   private initializeControllers(controller: Controller[]) {
     controller.forEach(controller => {
-      this.app.use('/', controller.boot());
+      // in the `openapi.yaml` we have prefix `v1` for all paths
+      this.app.use('/v1/', controller.boot());
     });
   }
 

--- a/src/controllers/tests/generator.controller.test.ts
+++ b/src/controllers/tests/generator.controller.test.ts
@@ -11,7 +11,7 @@ describe('GeneratorController', () => {
       const app = new App([new GenerateController()]);
 
       return request(app.getServer())
-        .post('/generate')
+        .post('/v1/generate')
         .send({
           asyncapi: {
             asyncapi: '2.2.0',
@@ -33,7 +33,7 @@ describe('GeneratorController', () => {
       const app = new App([new GenerateController()]);
 
       return request(app.getServer())
-        .post('/generate')
+        .post('/v1/generate')
         .send({
           asyncapi: {
             asyncapi: '2.2.0',
@@ -52,7 +52,7 @@ describe('GeneratorController', () => {
       const app = new App([new GenerateController()]);
 
       return request(app.getServer())
-        .post('/generate')
+        .post('/v1/generate')
         .send({
           asyncapi: {
             asyncapi: '2.2.0',

--- a/src/controllers/tests/validate.controller.test.ts
+++ b/src/controllers/tests/validate.controller.test.ts
@@ -82,7 +82,7 @@ describe('ValidateController', () => {
       const app = new App([new ValidateController()]);
 
       return request(app.getServer())
-        .post('/validate')
+        .post('/v1/validate')
         .send({
           asyncapi: validJSONAsyncAPI
         })
@@ -93,7 +93,7 @@ describe('ValidateController', () => {
       const app = new App([new ValidateController()]);
 
       return request(app.getServer())
-        .post('/validate')
+        .post('/v1/validate')
         .send({
           asyncapi: validYAMLAsyncAPI
         })
@@ -128,7 +128,7 @@ describe('ValidateController', () => {
       const app = new App([new ValidateController()]);
 
       return request(app.getServer())
-        .post('/validate')
+        .post('/v1/validate')
         .send({
           asyncapi: invalidJSONAsyncAPI
         })

--- a/src/middlewares/request-body-validation.middleware.ts
+++ b/src/middlewares/request-body-validation.middleware.ts
@@ -15,7 +15,9 @@ const ajv = new Ajv({
  * Retrieve proper AJV's validator function, create or reuse it.
  */
 async function getValidator(req: Request) {
-  const { path: reqPath, method } = req;
+  const method = req.method;
+  let reqPath = req.path;
+  reqPath = reqPath.startsWith('/v1') ? reqPath.replace('/v1', '') : reqPath;
   const schemaName = `${reqPath}->${method}`;
 
   const validate = ajv.getSchema(schemaName);

--- a/src/middlewares/tests/document-validation.middleware.test.ts
+++ b/src/middlewares/tests/document-validation.middleware.test.ts
@@ -21,7 +21,7 @@ describe('documentValidationMiddleware', () => {
       const app = new App([new TestController()]);
 
       return await request(app.getServer())
-        .post('/test')
+        .post('/v1/test')
         .send({})
         .expect(200, {
           success: true,
@@ -40,7 +40,7 @@ describe('documentValidationMiddleware', () => {
       const app = new App([new TestController()]);
 
       return await request(app.getServer())
-        .post('/test')
+        .post('/v1/test')
         .send({
           asyncapi: {
             asyncapi: '2.2.0',
@@ -97,7 +97,7 @@ describe('documentValidationMiddleware', () => {
       const app = new App([new TestController()]);
 
       return await request(app.getServer())
-        .post('/test')
+        .post('/v1/test')
         .send({
           // without title, version and channels
           asyncapi: {

--- a/src/middlewares/tests/problem.middleware.test.ts
+++ b/src/middlewares/tests/problem.middleware.test.ts
@@ -23,7 +23,7 @@ describe('problemMiddleware', () => {
       const app = new App([new TestController()]);
 
       return await request(app.getServer())
-        .post('/test')
+        .post('/v1/test')
         .send({})
         .expect(422, {
           type: ProblemException.createType('custom-problem'),
@@ -43,7 +43,7 @@ describe('problemMiddleware', () => {
       const app = new App([new TestController()]);
 
       return await request(app.getServer())
-        .post('/test')
+        .post('/v1/test')
         .send({})
         .expect(200, {
           success: true,

--- a/src/middlewares/tests/request-body-validation.middleware.test.ts
+++ b/src/middlewares/tests/request-body-validation.middleware.test.ts
@@ -20,7 +20,7 @@ describe('requestBodyValidationMiddleware', () => {
       const app = new App([new TestController()]);
 
       return await request(app.getServer())
-        .post('/generate')
+        .post('/v1/generate')
         .send({
           asyncapi: {
             asyncapi: '2.2.0',
@@ -39,7 +39,7 @@ describe('requestBodyValidationMiddleware', () => {
 
     it('should throw error when request body is invalid', async () => {
       const TestController = createTestController({
-        path: '/test',
+        path: '/generate',
         method: 'post',
         callback: (_, res) => {
           res.status(200).send({ success: true });
@@ -48,7 +48,7 @@ describe('requestBodyValidationMiddleware', () => {
       const app = new App([new TestController()]);
 
       return await request(app.getServer())
-        .post('/generate')
+        .post('/v1/generate')
         .send({
           asyncapi: {
             asyncapi: '2.2.0',


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title:
- add /v1 prefix to the all paths - as described in the `openapi.yaml`
- fix 200 response of /generate path: change `application/json` to the `application/octet-stream`.

I don't want to treat is a feat, but as fix, we forgot about that "things" in the previous PRs.

**Related issue(s)**
Fixes https://github.com/asyncapi/server-api/issues/34