### PR TITLE
fix: force 2 version of packageLock in the package-lock.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ WORKDIR /app
 COPY . .
 
 # install dependencies
-# switch to the `npm ci` when https://github.com/asyncapi/.github/issues/123 issue will be resolved
-RUN npm install
+# remove package-lock.json with lockVersion: 1 due to problem described in the https://github.com/asyncapi/.github/issues/123
+# remove first run and switch to the `npm ci` when mentioned issue will be resolved
+RUN rm package-lock.json; npm install
 
 # build to a production Javascript
 RUN npm run build:prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ FROM base AS build
 
 WORKDIR /app
 COPY . .
+
 # install dependencies
-RUN npm ci
+# switch to the `npm ci` when https://github.com/asyncapi/.github/issues/123 issue will be resolved
+RUN npm install
 
 # build to a production Javascript
 RUN npm run build:prod
@@ -24,8 +26,7 @@ FROM base AS release
 WORKDIR /app
 COPY --from=build /app/dist ./dist
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package* ./
+COPY --from=build /app/package* ./
 # install only production dependencies (defined in "dependencies")
 RUN npm ci --only=production 
 # copy OpenaAPI document


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- fix problem described in the https://github.com/asyncapi/.github/issues/123:
  - install by `npm install` not by `npm ci`
  - copy to the last image (`release`) the `package*` files from `build` image
  
**Related issue(s)**
Partially fixes https://github.com/asyncapi/.github/issues/123