### PR TITLE
fix: use node image as base to ensure version range

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # ---- Base Alpine with installed Node ----
-FROM alpine:3.14.3 AS base
+FROM node:14-alpine3.14 AS base
 
 # install node
 RUN apk add --update \
-  nodejs=14.18.1-r0 \
-  npm=7.17.0-r0 \
   nghttp2
 
 # ---- Install dependencies ----


### PR DESCRIPTION
**Description**

This PR fixes the current CI error on release: https://github.com/asyncapi/server-api/runs/5158849217?check_suite_focus=true.

The issue behind it is that alpine version got both `nodejs` and `npm` updated, so the specified version (`14.18.1-r0`) is no longer available.
In order to avoid the same problem in the future, we could either install both `nodejs` and `npm` packages without version modifier (not sure which version it will be installed if they keep updating it), use a fixed repository for installing those versions or rather, (the solution I chose) stick with `node` Docker image instead of `alpine` but with the `alpine` version tag:  `14-alpine3.14`, so we ensure any node version installed would be `14.x.x`.

Btw, I added `fix:` prefix to force a release because the previous one failed when publishing the Docker image to Docker hub.