### PR TITLE
chore: added Liveliness and Readiness Probes to K8S deployment

### DIFF
--- a/deployments/k8s/templates/deployment.yaml
+++ b/deployments/k8s/templates/deployment.yaml
@@ -40,6 +40,19 @@ spec:
             - name: http
               containerPort: {{ .Values.ports.http }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 30
+
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deployments/k8s/templates/deployment.yaml
+++ b/deployments/k8s/templates/deployment.yaml
@@ -43,15 +43,15 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 80
-            initialDelaySeconds: 30
-            periodSeconds: 60
+              port: {{ .Values.ports.http }}
+            initialDelaySeconds: {{ .Values.initialDelaySeconds.liveness }}
+            periodSeconds: {{ .Values.periodSeconds.liveness }}
           readinessProbe:
             httpGet:
               path: /
-              port: 80
-            initialDelaySeconds: 30
-            periodSeconds: 30
+              port: {{ .Values.ports.http }}
+            initialDelaySeconds: {{ .Values.initialDelaySeconds.readiness }}
+            periodSeconds: {{ .Values.periodSeconds.readiness }}
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deployments/k8s/values.yaml
+++ b/deployments/k8s/values.yaml
@@ -17,6 +17,14 @@ ports:
   # Port where the Server API will be available.
   http: 80
 
+#periodSeconds for livenees and Readiness Ports
+periodSeconds:
+  liveness: 10
+  readness: 6
+#initialDelaySeconds for liveness and Readiness Ports
+initialDelaySeconds:
+  liveness: 30
+  readness: 30
 # Env vars. Needed for configuring the app.
 env: {}
 

--- a/deployments/k8s/values.yaml
+++ b/deployments/k8s/values.yaml
@@ -20,11 +20,11 @@ ports:
 #periodSeconds for livenees and Readiness Ports
 periodSeconds:
   liveness: 10
-  readness: 6
+  readiness: 6
 #initialDelaySeconds for liveness and Readiness Ports
 initialDelaySeconds:
   liveness: 30
-  readness: 30
+  readiness: 30
 # Env vars. Needed for configuring the app.
 env: {}
 


### PR DESCRIPTION
fixes: #57
chore: [Added Liveliness and Readiness Probes to K8S deployment](https://github.com/asyncapi/server-api/pull/71#)
Signed-off-by: Abhijeet Jejurkar <abhijeet.jejurkar2@gmail.com>

**Description**

- Test NodeJS PR - windows-latest 
