### PR TITLE
feat: add the ability to send document references

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -242,6 +242,32 @@ components:
       minItems: 1
       items:
         $ref: '#/components/schemas/AsyncAPIDocument'
+    AsyncAPIDocumentInput:
+      description: AsyncAPI document in JSON or YAML with probable references.
+      oneOf: 
+        - $ref: '#/components/schemas/AsyncAPIDocument'
+        - type: object
+          properties:
+            document:
+              $ref: '#/components/schemas/AsyncAPIDocument'
+            references:
+              $ref: '#/components/schemas/DocumentReferences'
+          required:
+            - document
+            - references
+    AsyncAPIDocumentsInput:
+      type: array
+      description: AsyncAPI documents
+      minItems: 1
+      items:
+        $ref: '#/components/schemas/AsyncAPIDocumentInput'
+    DocumentReferences:
+      type: object
+      description: A dictionary where key is a reference and value is the value for the reference.
+      propertyNames:
+        type: string
+      additionalProperties:
+        type: string
     SpecVersions:
       type: string
       description: Valid specification versions for the AsyncAPI document.
@@ -256,6 +282,7 @@ components:
         - '2.2.0'
         - '2.3.0'
         - 'latest'
+    
 
     GenerateRequest:
       type: object
@@ -264,7 +291,7 @@ components:
         - template
       properties:
         asyncapi:
-          $ref: "#/components/schemas/AsyncAPIDocument"
+          $ref: "#/components/schemas/AsyncAPIDocumentInput"
         template:
           type: string
           description: Template name to be generated.
@@ -297,7 +324,7 @@ components:
         - asyncapi
       properties:
         asyncapi:
-          $ref: '#/components/schemas/AsyncAPIDocument'
+          $ref: '#/components/schemas/AsyncAPIDocumentInput'
 
     ConvertRequest:
       type: object
@@ -305,7 +332,7 @@ components:
         - asyncapi
       properties:
         asyncapi:
-          $ref: '#/components/schemas/AsyncAPIDocument'
+          $ref: '#/components/schemas/AsyncAPIDocumentInput'
         version:
           $ref: '#/components/schemas/SpecVersions'
         language:
@@ -327,9 +354,9 @@ components:
         - asyncapis 
       properties:
         asyncapis:
-          $ref: "#/components/schemas/AsyncAPIDocuments"
+          $ref: "#/components/schemas/AsyncAPIDocumentsInput"
         base:
-          $ref: "#/components/schemas/AsyncAPIDocument"
+          $ref: "#/components/schemas/AsyncAPIDocumentInput"
     BundleResponse:
       type: object
       required:
@@ -348,7 +375,7 @@ components:
           minItems: 2
           maxItems: 2
           items:
-            $ref: '#/components/schemas/AsyncAPIDocument'
+            $ref: '#/components/schemas/AsyncAPIDocumentInput'
     DiffResponse:
       type: object
       properties:

--- a/src/controllers/bundle.controller.ts
+++ b/src/controllers/bundle.controller.ts
@@ -4,17 +4,18 @@ import bundler from '@asyncapi/bundler';
 import { validationMiddleware } from '../middlewares/validation.middleware';
 
 import { ProblemException } from '../exceptions/problem.exception';
-import { Controller } from '../interfaces';
+import { Controller, ParsedAsyncAPIDocument } from '../interfaces';
 
 export class BundleController implements Controller {
   public basepath = '/bundle';
 
   private async bundle(req: Request, res: Response, next: NextFunction) {
-    const asyncapis: Array<string> = req.body.asyncapis;
-    const base = req.body.base;
+    const asyncapis = req.asyncapi.documents.asyncapis as Array<ParsedAsyncAPIDocument>;
+    const rawAsyncapis = asyncapis.map(asyncapi => asyncapi.raw);
+    const base = req.asyncapi.documents.base as ParsedAsyncAPIDocument;
 
     try {
-      const document = await bundler(asyncapis, { base });
+      const document = await bundler(rawAsyncapis, { base: base.raw });
       const bundled = document.json();
       res.status(200).json({ bundled });
     } catch (err) {

--- a/src/controllers/convert.controller.ts
+++ b/src/controllers/convert.controller.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response, Router } from 'express';
 
-import { Controller, AsyncAPIDocument, SpecsEnum } from '../interfaces';
+import { Controller, AsyncAPIDocument, SpecsEnum, ParsedAsyncAPIDocument } from '../interfaces';
 
 import { validationMiddleware } from '../middlewares/validation.middleware';
 
@@ -31,9 +31,10 @@ export class ConvertController implements Controller {
 
   private async convert(req: Request, res: Response, next: NextFunction) {
     try {
-      const { version, language, asyncapi } = req.body as ConvertRequestDto;
+      const asyncapi = req.asyncapi.documents.asyncapi as ParsedAsyncAPIDocument;
+      const { version, language } = req.body as ConvertRequestDto;
       const convertedSpec = await this.convertService.convert(
-        asyncapi,
+        asyncapi.raw,
         version,
         language,
       );

--- a/src/controllers/diff.controller.ts
+++ b/src/controllers/diff.controller.ts
@@ -4,16 +4,16 @@ import { diff } from '@asyncapi/diff';
 import { validationMiddleware } from '../middlewares/validation.middleware';
 
 import { ProblemException } from '../exceptions/problem.exception';
-import { Controller} from '../interfaces';
+import { Controller, ParsedAsyncAPIDocument } from '../interfaces';
 
 export class DiffController implements Controller {
   public basepath = '/diff';
 
   private async diff(req: Request, res: Response, next: NextFunction) {
-    const { asyncapis } = req.body;
+    const asyncapis = req.asyncapi.documents.asyncapis as Array<ParsedAsyncAPIDocument>;
 
     try {
-      const output = diff(asyncapis[0], asyncapis[1]).getOutput();
+      const output = diff(asyncapis[0].raw, asyncapis[1].raw).getOutput();
       res.status(200).json({ diff: output });
     } catch (err) {
       return next(new ProblemException({

--- a/src/controllers/tests/generate.controller.test.ts
+++ b/src/controllers/tests/generate.controller.test.ts
@@ -7,7 +7,7 @@ import { GenerateController } from '../generate.controller';
 
 describe('GeneratorController', () => {
   describe('[POST] /generate', () => {
-    it('should generate template ', async () => {
+    it('should generate template', async () => {
       const app = new App([new GenerateController()]);
       await app.init();
 
@@ -30,7 +30,7 @@ describe('GeneratorController', () => {
         .expect(200);
     });
 
-    it('should pass when sent template parameters are empty', async () => {
+    it('should generate when sent template parameters are empty', async () => {
       const app = new App([new GenerateController()]);
       await app.init();
 
@@ -46,6 +46,54 @@ describe('GeneratorController', () => {
             channels: {},
           },
           template: '@asyncapi/html-template',
+        })
+        .expect(200);
+    });
+
+    it('should generate template with document references', async () => {
+      const app = new App([new GenerateController()]);
+      await app.init();
+
+      return request(app.getServer())
+        .post('/v1/generate')
+        .send({
+          asyncapi: {
+            document: {
+              asyncapi: '2.0.0',
+              info: {
+                title: 'Super test',
+                version: '1.0.0'
+              },
+              channels: {
+                someChannel1: {
+                  $ref: '../some-file.json#/components/someChannel',
+                },
+                someChannel2: {
+                  $ref: '../../another-file.json#/components/someChannel',
+                }
+              }
+            },
+            references: {
+              '../some-file.json': {
+                components: {
+                  someChannel: {
+                    $ref: '../another-file.json#/components/someChannel',
+                  }
+                }
+              },
+              '../../another-file.json': {
+                components: {
+                  someChannel: {
+                    subscribe: {},
+                  }
+                }
+              }
+            }
+          },
+          template: '@asyncapi/html-template',
+          parameters: {
+            version: '2.1.37',
+          }
         })
         .expect(200);
     });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,5 @@
 import specs from '@asyncapi/specs';
+import { AsyncAPIDocument as ParserAsyncAPIDocument } from '@asyncapi/parser';
 import { Router } from 'express';
 
 export interface Controller {
@@ -16,6 +17,12 @@ export interface Problem {
 }
 
 export type AsyncAPIDocument = { asyncapi: string } & Record<string, unknown>;
+export type ParsedAsyncAPIDocument = {
+  raw: string | AsyncAPIDocument;
+  parsed: ParserAsyncAPIDocument;
+}
+
+export type References = Record<string, unknown>;
 
 export const ALL_SPECS = [...Object.keys(specs)];
 export const LAST_SPEC_VERSION = ALL_SPECS[ALL_SPECS.length - 1];

--- a/src/middlewares/tests/validation.middleware.test.ts
+++ b/src/middlewares/tests/validation.middleware.test.ts
@@ -218,4 +218,160 @@ describe('validationMiddleware', () => {
         }
       });
   });
+
+  it('should pass when `asyncapi` field is defined as valid AsyncAPI document with references', async () => {
+    const TestController = createTestController({
+      path: '/generate',
+      method: 'post',
+      callback: (_, res) => {
+        res.status(200).send({ success: true });
+      },
+      middlewares: [
+        await validationMiddleware({
+          path: '/generate',
+          method: 'post',
+          documents: ['asyncapi'],
+        }),
+      ],
+    });
+    const app = new App([new TestController()]);
+    await app.init();
+
+    return await request(app.getServer())
+      .post('/v1/generate')
+      .send({
+        template: '@asyncapi/html-template',
+        asyncapi: {
+          document: {
+            asyncapi: '2.0.0',
+            info: {
+              title: 'Super test',
+              version: '1.0.0'
+            },
+            channels: {
+              someChannel1: {
+                $ref: '../some-file.json#/components/someChannel',
+              },
+              someChannel2: {
+                $ref: '../../another-file.json#/components/someChannel',
+              }
+            }
+          },
+          references: {
+            '../some-file.json': {
+              components: {
+                someChannel: {
+                  $ref: '../another-file.json#/components/someChannel',
+                }
+              }
+            },
+            '../../another-file.json': {
+              components: {
+                someChannel: {
+                  subscribe: {},
+                }
+              }
+            }
+          }
+        }
+      })
+      .expect(200, {
+        success: true,
+      });
+  });
+
+  it('should pass when `asyncapis` field is defined as valid AsyncAPI documents with references', async () => {
+    const TestController = createTestController({
+      path: '/diff',
+      method: 'post',
+      callback: (_, res) => {
+        res.status(200).send({ success: true });
+      },
+      middlewares: [
+        await validationMiddleware({
+          path: '/diff',
+          method: 'post',
+          documents: ['asyncapis'],
+        }),
+      ],
+    });
+    const app = new App([new TestController()]);
+    await app.init();
+
+    return await request(app.getServer())
+      .post('/v1/diff')
+      .send({
+        asyncapis: [
+          {
+            document: {
+              asyncapi: '2.0.0',
+              info: {
+                title: 'Super test',
+                version: '1.0.0'
+              },
+              channels: {
+                someChannel1: {
+                  $ref: '../some-file.json#/components/someChannel',
+                },
+                someChannel2: {
+                  $ref: '../../another-file.json#/components/someChannel',
+                }
+              }
+            },
+            references: {
+              '../some-file.json': {
+                components: {
+                  someChannel: {
+                    $ref: '../another-file.json#/components/someChannel',
+                  }
+                }
+              },
+              '../../another-file.json': {
+                components: {
+                  someChannel: {
+                    subscribe: {},
+                  }
+                }
+              }
+            }
+          },
+          {
+            document: {
+              asyncapi: '2.0.0',
+              info: {
+                title: 'Super test',
+                version: '1.0.0'
+              },
+              channels: {
+                someChannel1: {
+                  $ref: '../some-file.json#/components/someChannel',
+                },
+                someChannel2: {
+                  $ref: '../../another-file.json#/components/someChannel',
+                }
+              }
+            },
+            references: {
+              '../some-file.json': {
+                components: {
+                  someChannel: {
+                    $ref: '../another-file.json#/components/someChannel',
+                  }
+                }
+              },
+              '../../another-file.json': {
+                components: {
+                  someChannel: {
+                    subscribe: {},
+                  }
+                }
+              }
+            }
+          }
+        ],
+      })
+      .expect(200, {
+        success: true,
+      });
+  });
 });

--- a/src/server-api.d.ts
+++ b/src/server-api.d.ts
@@ -1,7 +1,9 @@
-import { AsyncAPIDocument } from '@asyncapi/parser';
+import type { ParsedAsyncAPIDocument } from './interfaces';
 
 declare module 'express' {
   export interface Request {
-    parsedDocument?: AsyncAPIDocument;
+    asyncapi: {
+      documents: Record<string, ParsedAsyncAPIDocument | Array<ParsedAsyncAPIDocument>>;
+    };
   }
 }

--- a/src/services/generator.service.ts
+++ b/src/services/generator.service.ts
@@ -1,8 +1,6 @@
 // @ts-ignore
 import AsyncAPIGenerator from '@asyncapi/generator';
-import { AsyncAPIDocument } from '@asyncapi/parser';
-
-import { prepareParserConfig } from '../utils/parser';
+import { AsyncAPIDocument, ParserOptions } from '@asyncapi/parser';
 
 /**
  * Service providing `@asyncapi/generate` functionality.
@@ -13,7 +11,7 @@ export class GeneratorService {
     template: string,
     parameters: Record<string, any>,
     destDir: string,
-    parserOptions: ReturnType<typeof prepareParserConfig>,
+    parserOptions: ParserOptions,
   ) {
     const generator = new AsyncAPIGenerator(template, destDir, {
       forceWrite: true,

--- a/src/services/parser.service.ts
+++ b/src/services/parser.service.ts
@@ -124,12 +124,6 @@ export class ParserService {
     return {
       resolve: {
         file: fileResolver,
-        http: {
-          headers: {
-            Cookie: req.header('Cookie'),
-          },
-          withCredentials: true,
-        },
       },
     };
   }

--- a/src/services/parser.service.ts
+++ b/src/services/parser.service.ts
@@ -46,8 +46,8 @@ export class ParserService {
       return {
         parsed,
         raw: document,
-      }
-    } catch(err: unknown) {
+      };
+    } catch (err: unknown) {
       throw this.tryConvertToProblem(err);
     }
   }
@@ -118,7 +118,7 @@ export class ParserService {
         read(file: { url: string }) {
           return serializeRefs[String(file.url)];
         }
-      }
+      };
     }
 
     return {

--- a/src/services/parser.service.ts
+++ b/src/services/parser.service.ts
@@ -1,0 +1,136 @@
+import path from 'path';
+
+import { registerSchemaParser, parse, ParserError } from '@asyncapi/parser';
+import { ProblemException } from '../exceptions/problem.exception';
+
+import ramlDtParser from '@asyncapi/raml-dt-schema-parser';
+import openapiSchemaParser from '@asyncapi/openapi-schema-parser';
+import avroSchemaParser from '@asyncapi/avro-schema-parser';
+
+import { retrieveDocument } from '../utils/retrieve-document';
+
+import type { Request } from 'express';
+import type { ParserOptions } from '@asyncapi/parser';
+import type { AsyncAPIDocument, ParsedAsyncAPIDocument, References } from '../interfaces';
+
+registerSchemaParser(openapiSchemaParser);
+registerSchemaParser(ramlDtParser);
+registerSchemaParser(avroSchemaParser);
+
+/**
+ * Service providing `@asyncapi/parser` functionality.
+ */
+export class ParserService {
+  private TYPES_400 = [
+    'null-or-falsey-document',
+    'impossible-to-convert-to-json',
+    'invalid-document-type',
+    'invalid-json',
+    'invalid-yaml',
+  ];
+
+  public async parse(
+    asyncapi: string | AsyncAPIDocument | { document: string | AsyncAPIDocument, references: References },
+    req: Request,
+  ): Promise<ParsedAsyncAPIDocument> {
+    const { document, references } = retrieveDocument(asyncapi);
+
+    let documentCopy = document;
+    if (typeof document === 'object') {
+      documentCopy = JSON.parse(JSON.stringify(document));
+    }
+    const options = ParserService.createConfig(req, references);
+
+    try {
+      const parsed = await parse(documentCopy, options);
+      return {
+        parsed,
+        raw: document,
+      }
+    } catch(err: unknown) {
+      throw this.tryConvertToProblem(err);
+    }
+  }
+
+  private tryConvertToProblem(err: any) {
+    let error = err;
+    if (error instanceof ParserError) {
+      const typeName = err.type.replace('https://github.com/asyncapi/parser-js/', '');
+      error = new ProblemException({
+        type: typeName,
+        title: err.title,
+        status: this.retrieveStatusCode(typeName),
+      });
+      this.mergeParserError(error, err);
+    }
+    return error;
+  }
+
+  private retrieveStatusCode(type: string): number {
+    if (this.TYPES_400.includes(type)) {
+      return 400;
+    }
+    return 422;
+  }
+  
+  /**
+   * Merges fields from ParserError to ProblemException.
+   */
+  private mergeParserError(error: ProblemException, parserError: any): ProblemException {
+    if (parserError.detail) {
+      error.detail = parserError.detail;
+    }
+    if (parserError.validationErrors) {
+      error.validationErrors = parserError.validationErrors;
+    }
+    if (parserError.parsedJSON) {
+      error.parsedJSON = parserError.parsedJSON;
+    }
+    if (parserError.location) {
+      error.location = parserError.location;
+    }
+    if (parserError.refs) {
+      error.refs = parserError.refs;
+    }
+    return error;
+  }
+
+  static createConfig(req: Request = undefined, references: References = {}): ParserOptions {
+    if (!req) {
+      return {
+        resolve: {
+          file: false,
+        },
+      };
+    }
+
+    let fileResolver: any = false;
+    if (Object.keys(references).length) {
+      const serializeRefs = Object.entries(references).reduce((acc, [ref, value]) => {
+        acc[path.resolve(process.cwd(), ref)] = value;
+        return acc;
+      }, {} as References);
+
+      fileResolver = {
+        canRead(file: { url: string }) {
+          return serializeRefs[String(file.url)] !== undefined;
+        },
+        read(file: { url: string }) {
+          return serializeRefs[String(file.url)];
+        }
+      }
+    }
+
+    return {
+      resolve: {
+        file: fileResolver,
+        http: {
+          headers: {
+            Cookie: req.header('Cookie'),
+          },
+          withCredentials: true,
+        },
+      },
+    };
+  }
+}

--- a/src/services/tests/parser.service.test.ts
+++ b/src/services/tests/parser.service.test.ts
@@ -7,7 +7,7 @@ import { ProblemException } from '../../exceptions/problem.exception';
 describe('ParserService', () => {
   const parserService = new ParserService();
   const req = {
-    header() { return '' },
+    header() { return ''; },
   } as unknown as Request;
 
   describe('.parse()', () => {
@@ -204,13 +204,9 @@ describe('ParserService', () => {
       expect(parsed).toEqual(undefined);
       expect(err).toBeInstanceOf(ProblemException);
       expect(ProblemException.toJSON(err).type).toEqual(ProblemException.createType('dereference-error'));
-    })
+    });
 
     it('should throw error due to invalid AsyncAPI document', async () => {
-      const options = ParserService.createConfig({
-        header() { return '' },
-      } as any);
-
       let err: ProblemException;
       let parsed: AsyncAPIDocument;
       try {

--- a/src/services/tests/parser.service.test.ts
+++ b/src/services/tests/parser.service.test.ts
@@ -1,0 +1,260 @@
+import { AsyncAPIDocument } from '@asyncapi/parser';
+import { Request } from 'express';
+
+import { ParserService } from '../parser.service';
+import { ProblemException } from '../../exceptions/problem.exception';
+
+describe('ParserService', () => {
+  const parserService = new ParserService();
+  const req = {
+    header() { return '' },
+  } as unknown as Request;
+
+  describe('.parse()', () => {
+    it('should parse spec with single file reference', async () => {      
+      let err: ProblemException;
+      let parsed: AsyncAPIDocument;
+      try {
+        ({ parsed } = await parserService.parse({
+          document: {
+            asyncapi: '2.0.0',
+            info: {
+              title: 'Super test',
+              version: '1.0.0'
+            },
+            channels: {
+              someChannel: {
+                $ref: './some-file.json#/components/someChannel',
+              }
+            }
+          },
+          references: {
+            './some-file.json': {
+              components: {
+                someChannel: {
+                  publish: {},
+                }
+              }
+            },
+          }
+        }, req));
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toEqual(undefined);
+      expect(parsed.json().channels.someChannel).toEqual({ publish: {} });
+    });
+
+    it('should parse spec with file references (more than one)', async () => {      
+      let err: ProblemException;
+      let parsed: AsyncAPIDocument;
+      try {
+        ({ parsed } = await parserService.parse({
+          document: {
+            asyncapi: '2.0.0',
+            info: {
+              title: 'Super test',
+              version: '1.0.0'
+            },
+            channels: {
+              someChannel1: {
+                $ref: './some-file.json#/components/someChannel',
+              },
+              someChannel2: {
+                $ref: '../../another-file.json#/components/someChannel',
+              }
+            }
+          },
+          references: {
+            './some-file.json': {
+              components: {
+                someChannel: {
+                  publish: {},
+                }
+              }
+            },
+            '../../another-file.json': {
+              components: {
+                someChannel: {
+                  subscribe: {},
+                }
+              }
+            },
+          }
+        }, req));
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toEqual(undefined);
+      expect(parsed.json().channels.someChannel1).toEqual({ publish: {} });
+      expect(parsed.json().channels.someChannel2).toEqual({ subscribe: {} });
+    });
+
+    it('should parse spec with file references (one use another one)', async () => {      
+      let err: ProblemException;
+      let parsed: AsyncAPIDocument;
+      try {
+        ({ parsed } = await parserService.parse({
+          document: {
+            asyncapi: '2.0.0',
+            info: {
+              title: 'Super test',
+              version: '1.0.0'
+            },
+            channels: {
+              someChannel1: {
+                $ref: '../some-file.json#/components/someChannel',
+              },
+              someChannel2: {
+                $ref: '../../another-file.json#/components/someChannel',
+              }
+            }
+          },
+          references: {
+            '../some-file.json': {
+              components: {
+                someChannel: {
+                  $ref: '../another-file.json#/components/someChannel',
+                }
+              }
+            },
+            '../../another-file.json': {
+              components: {
+                someChannel: {
+                  subscribe: {},
+                }
+              }
+            },
+          }
+        }, req));
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toEqual(undefined);
+      expect(parsed.json().channels.someChannel1).toEqual({ subscribe: {} });
+      expect(parsed.json().channels.someChannel2).toEqual({ subscribe: {} });
+    });
+
+    it('should parse spec with http references', async () => {      
+      let err: ProblemException;
+      let parsed: AsyncAPIDocument;
+      try {
+        ({ parsed } = await parserService.parse({
+          document: {
+            asyncapi: '2.0.0',
+            info: {
+              title: 'Super test',
+              version: '1.0.0'
+            },
+            channels: {
+              someChannel1: {
+                $ref: './some-file.json#/components/someChannel',
+              },
+              someChannel2: {
+                subscribe: {
+                  message: {
+                    $ref: 'https://raw.githubusercontent.com/asyncapi/spec/master/examples/simple.yml#/components/messages/UserSignedUp',
+                  }
+                }
+              }
+            }
+          },
+          references: {
+            './some-file.json': {
+              components: {
+                someChannel: {
+                  publish: {},
+                }
+              }
+            },
+          }
+        }, req));
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toEqual(undefined);
+      expect(parsed.json().channels.someChannel1).toEqual({ publish: {} });
+      expect(typeof parsed.json().channels.someChannel2.subscribe.message.payload).toEqual('object');
+    });
+
+    it('should throw error due to non existing reference', async () => {
+      let err: ProblemException;
+      let parsed: AsyncAPIDocument;
+      try {
+        ({ parsed } = await parserService.parse({
+          asyncapi: '2.0.0',
+          info: {
+            title: 'Super test',
+            version: '1.0.0'
+          },
+          channels: {
+            someChannel: {
+              $ref: './some-file.json#/components/someChannel',
+            }
+          }
+        }, req));
+      } catch (e) {
+        err = e;
+      }
+
+      expect(parsed).toEqual(undefined);
+      expect(err).toBeInstanceOf(ProblemException);
+      expect(ProblemException.toJSON(err).type).toEqual(ProblemException.createType('dereference-error'));
+    })
+
+    it('should throw error due to invalid AsyncAPI document', async () => {
+      const options = ParserService.createConfig({
+        header() { return '' },
+      } as any);
+
+      let err: ProblemException;
+      let parsed: AsyncAPIDocument;
+      try {
+        ({ parsed } = await parserService.parse({
+          asyncapi: '2.0.0',
+          info: {
+            tite: 'My API',
+            version: '1.0.0'
+          },
+          channels: {}
+        }, req));
+      } catch (e) {
+        err = e;
+      }
+
+      expect(parsed).toEqual(undefined);
+      expect(err).toBeInstanceOf(ProblemException);
+      expect(ProblemException.toJSON(err)).toEqual({
+        type: ProblemException.createType('validation-errors'),
+        title: 'There were errors validating the AsyncAPI document.',
+        status: 422,
+        validationErrors: [
+          {
+            title: '/info should NOT have additional properties',
+            location: {
+              jsonPointer: '/info'
+            }
+          },
+          {
+            title: '/info should have required property \'title\'',
+            location: {
+              jsonPointer: '/info'
+            }
+          }
+        ],
+        parsedJSON: {
+          asyncapi: '2.0.0',
+          info: {
+            tite: 'My API',
+            version: '1.0.0'
+          },
+          channels: {}
+        }
+      });
+    });
+  });
+});

--- a/src/services/tests/parser.service.test.ts
+++ b/src/services/tests/parser.service.test.ts
@@ -206,6 +206,31 @@ describe('ParserService', () => {
       expect(ProblemException.toJSON(err).type).toEqual(ProblemException.createType('dereference-error'));
     });
 
+    it('should throw error due to non existing reference - check fs', async () => {
+      let err: ProblemException;
+      let parsed: AsyncAPIDocument;
+      try {
+        ({ parsed } = await parserService.parse({
+          asyncapi: '2.0.0',
+          info: {
+            title: 'Super test',
+            version: '1.0.0'
+          },
+          channels: {
+            someChannel: {
+              $ref: './openapi.yaml',
+            }
+          }
+        }, req));
+      } catch (e) {
+        err = e;
+      }
+
+      expect(parsed).toEqual(undefined);
+      expect(err).toBeInstanceOf(ProblemException);
+      expect(ProblemException.toJSON(err).type).toEqual(ProblemException.createType('dereference-error'));
+    });
+
     it('should throw error due to invalid AsyncAPI document', async () => {
       let err: ProblemException;
       let parsed: AsyncAPIDocument;

--- a/src/utils/retrieve-document.ts
+++ b/src/utils/retrieve-document.ts
@@ -10,5 +10,5 @@ export function retrieveDocument(body: string | AsyncAPIDocument | { document: s
   return {
     document: body as string | AsyncAPIDocument,
     references: undefined,
-  }
+  };
 }

--- a/src/utils/retrieve-document.ts
+++ b/src/utils/retrieve-document.ts
@@ -1,0 +1,14 @@
+import type { AsyncAPIDocument, References } from '../interfaces';
+
+export function retrieveDocument(body: string | AsyncAPIDocument | { document: string | AsyncAPIDocument, references: References }): { document: string | AsyncAPIDocument, references: References | undefined } {
+  if (typeof body === 'object' && Object.keys(body).length === 2 && body.references && typeof body.references === 'object') {
+    return {
+      document: body.document as string | AsyncAPIDocument,
+      references: body.references as References,
+    };
+  }
+  return {
+    document: body as string | AsyncAPIDocument,
+    references: undefined,
+  }
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Currently people cannot send AsyncAPI document with local references. That PR adds that ability. Sending example request:

```js
{
  asyncapi: {
            document: {
              asyncapi: '2.0.0',
              info: {
                title: 'Super test',
                version: '1.0.0'
              },
              channels: {
                someChannel1: {
                  $ref: '../some-file.json#/components/someChannel',
                },
                someChannel2: {
                  $ref: '../../another-file.json#/components/someChannel',
                }
              }
            },
            references: {
              '../some-file.json': {
                components: {
                  someChannel: {
                    $ref: '../another-file.json#/components/someChannel',
                  }
                }
              },
              '../../another-file.json': {
                components: {
                  someChannel: {
                    subscribe: {},
                  }
                }
              }
            }
  },
  ...
}
```

we can resolve local references. It will work on every path. Check for more examples in written unit tests.