### PR TITLE
chore: add info about digital ocean to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ server is ready to use on [http://localhost:80](http://localhost:80).
 
 Read [CONTRIBUTING](https://github.com/asyncapi/.github/blob/master/CONTRIBUTING.md) guide.
 
-## Contributors ✨
+## Supported by
+
+<p>
+  <a href="https://www.digitalocean.com/">
+    <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" width="201px">
+  </a>
+</p>
+
+## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 


### PR DESCRIPTION
DigitalOcean extended support for us.
We received $1200 until the end of this year.
One of requirements is to make it transparent in readme what projects are hosted on DigitalOcean