### PR TITLE
feat: enable push to NPM registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+access=public


### PR DESCRIPTION
**Description**

We never published our NPM package to NPM registry. As it is the first time we do, we need to specify that the package (scoped package) is public, otherwise it will be considered as restricted and our push command in CI will fail, as in [here](https://github.com/asyncapi/server-api/actions/runs/7708747112/job/21008553149#step:9:642).

More info: https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages

We have several ways of doing this, we could just publish **manually** our first version to NPM, but that's not pretty cool since we would need to ask someone with the credentials (NPM TOKEN) to do. 
Instead, we can just add this `.npmrc` file with the right config to tell NPM this is a public scoped package. Alternatively, we could [add a config for semantic-release](https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-set-the-access-level-of-the-published-npm-package), but I believe this should be in the `.npmrc` since it is purely related to NPM.